### PR TITLE
Add authentication to the API

### DIFF
--- a/app/src/main/java/com/example/elephantbook_fieldguide/Converters.kt
+++ b/app/src/main/java/com/example/elephantbook_fieldguide/Converters.kt
@@ -1,6 +1,7 @@
 package com.example.elephantbook_fieldguide
 
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.room.TypeConverter
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
@@ -13,11 +14,8 @@ class Converters {
     }
 
     @TypeConverter
+    @RequiresApi(Build.VERSION_CODES.O)
     fun toOffsetDateTime(dateTime: String) : OffsetDateTime {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            OffsetDateTime.parse(dateTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-        } else {
-            TODO("VERSION.SDK_INT < O")
-        }
+        return OffsetDateTime.parse(dateTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     }
 }

--- a/app/src/main/java/com/example/elephantbook_fieldguide/MainActivity.kt
+++ b/app/src/main/java/com/example/elephantbook_fieldguide/MainActivity.kt
@@ -12,7 +12,6 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         findViewById<Button>(R.id.button).setOnClickListener { showIndividual(it) }
-
     }
 
     private fun showIndividual(view: View) {

--- a/app/src/main/java/com/example/elephantbook_fieldguide/MainActivity.kt
+++ b/app/src/main/java/com/example/elephantbook_fieldguide/MainActivity.kt
@@ -11,14 +11,16 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        findViewById<Button>(R.id.button).setOnClickListener { showIndividual(it) }
+        DatabaseWrapper.create(applicationContext).updateDatabase {
+            findViewById<Button>(R.id.button).setOnClickListener { showIndividual(it) }
+        }
     }
 
     private fun showIndividual(view: View) {
         startActivity(Intent(this, IndividualActivity::class.java).apply {
             putExtra(
                 "elephantId",
-                5
+                2
             )
         })
     }

--- a/app/src/main/java/com/example/elephantbook_fieldguide/Secrets.kt
+++ b/app/src/main/java/com/example/elephantbook_fieldguide/Secrets.kt
@@ -1,6 +1,10 @@
 package com.example.elephantbook_fieldguide
 
 class Secrets {
-    val apiUrl = "https://localhost/individuals.json"
-    val imageUrl = "https://localhost/"
+    companion object {
+        const val apiUrl = "https://localhost/individuals.json"
+        const val imageUrl = "https://localhost/"
+        const val apiUsername = "user"
+        const val apiPassword = "pass"
+    }
 }

--- a/app/src/main/java/com/example/elephantbook_fieldguide/Secrets.kt
+++ b/app/src/main/java/com/example/elephantbook_fieldguide/Secrets.kt
@@ -1,10 +1,20 @@
 package com.example.elephantbook_fieldguide
 
+import android.util.Base64
+
 class Secrets {
     companion object {
         const val apiUrl = "https://localhost/individuals.json"
         const val imageUrl = "https://localhost/"
-        const val apiUsername = "user"
-        const val apiPassword = "pass"
+        private const val apiUsername = "user"
+        private const val apiPassword = "pass"
+
+        val apiAuthHeaders = mapOf("Authorization" to "Basic ${
+            // https://en.wikipedia.org/wiki/Basic_access_authentication
+            Base64.encodeToString(
+                    "${apiUsername}:${apiPassword}".toByteArray(),
+                    Base64.NO_WRAP
+            )
+        }")
     }
 }


### PR DESCRIPTION
Adds HTTP Basic Authorization to the ApiGetter class so we can use it with the new API. Both the JSON request and the image requests support this authentication.

Big refactor in `ApiGetter.downloadImage` is caused by the move from an ImageLoader to an ImageRequest. The logic is mostly the same but it allows us to override `getHeaders` to insert the basic auth credentials, while the ImageLoader request is not exposed. Tested and working on my device

Resolves #31
Resolves #32